### PR TITLE
"docker ps" to "docker logs"

### DIFF
--- a/docs/f5-asp-and-controller/f5-asp-and-controller-installation.rst
+++ b/docs/f5-asp-and-controller/f5-asp-and-controller-installation.rst
@@ -24,7 +24,7 @@ Copy/Paste the following JSON blob:
   		"container": {
 			"type": "DOCKER",
 			"docker": {
-			"image": "10.1.10.11:5000/marathon-asp-ctlr:v1.0.0",
+			"image": "f5networks/marathon-asp-ctlr:1.0.0",
 			"network": "BRIDGE",
 			"forcePullImage": true,
 			"privileged": false,

--- a/docs/f5-container-connector/f5-container-connector-installation.rst
+++ b/docs/f5-container-connector/f5-container-connector-installation.rst
@@ -117,7 +117,7 @@ To check the logs of our Controller:
 
 .. code-block:: none
 
-  sudo docker ps a0017f8c44fb
+  sudo docker logs a0017f8c44fb
 
 
 

--- a/docs/f5-container-connector/f5-container-connector-installation.rst
+++ b/docs/f5-container-connector/f5-container-connector-installation.rst
@@ -63,7 +63,7 @@ Use the following JSON config
     "container": {
       "type": "DOCKER",
       "docker": {
-        "image": "10.1.10.11:5000/marathon-bigip-ctlr:v1.0.0",
+        "image": "f5networks/marathon-bigip-ctlr:1.0.0",
         "network": "BRIDGE"
       }
     },


### PR DESCRIPTION
"docker ps" accepts no argument(s).
It was probably a typo.
Changed to "docker logs".